### PR TITLE
Small documentation fixes

### DIFF
--- a/src/documentation/language-reference/definitions/functions.md
+++ b/src/documentation/language-reference/definitions/functions.md
@@ -122,7 +122,7 @@ Then {%ard%} x {%endard%} is equivalent to this pattern.
 Now, let us discuss how expressions of the form {%ard%} f a_1 ... a_n {%endard%} evaluate (see [Expressions](../expressions#evaluation) for the definition of the reduction and evaluation relations).
 Let {%ard%} E {%endard%} be equal to {%ard%} f a_1 ... a_n {%endard%}.
 To reduce this expression, we first evaluate expressions {%ard%} a_1, ... a_n {%endard%} and match them with the patterns in the definition of {%ard%} f {%endard%} left to right, top to bottom.
-If all patterns {%ard%} p^i_1, ... p^i_n {%endard%} matches with {%ard%} a_1, ... a_n {%endard%} for some i, then {%ard%} E {%endard%} reduces to {%ard%} e_i[b_1/y_1, ... b_k/y_k] {%endard%},
+If all patterns {%ard%} p^i_1, ... p^i_n {%endard%} matches with {%ard%} a_1, ... a_n {%endard%} for some _i_, then {%ard%} E {%endard%} reduces to {%ard%} e_i[b_1/y_1, ... b_k/y_k] {%endard%},
 where {%ard%} y_1, ... y_k {%endard%} are variables that appear in {%ard%} p^i_1, ... p^i_n {%endard%} and {%ard%} b_1, ... b_k {%endard%} are subexpressions of {%ard%} a_1, ... a_n {%endard%} corresponding to these variables.
 If some argument cannot be matched with a pattern {%ard%} con s_1 ... s_m {%endard%} because it is of the form {%ard%} con' ... {%endard%} for some constructor {%ard%} con' {%endard%} different from {%ard%} con {%endard%},
 then the evaluator skips the clause with this patterns and tries the next one.

--- a/src/documentation/language-reference/definitions/level.md
+++ b/src/documentation/language-reference/definitions/level.md
@@ -64,7 +64,7 @@ Similarly, a property of type {%ard%} A {%endard%} can be defined as follows:
 
 {% arend %}
 \record R {
-  \property p : \level A p
+  \property s : \level A p
 }
 {% endarend %}
 
@@ -95,7 +95,7 @@ So, in this case, {%ard%} \use \level {%endard%} is just a syntactic sugar.
 If some function {%ard%} f {%endard%} is defined with a {%ard%} \use \level {%endard%} annotation, this does not change the type of {%ard%} f {%endard%},
 but it will be treated as a type in a lower universe in situations described in [Level of a type](#level-of-a-type).
 
-For example, we can prove that {%ard%} isProp {%endard%} is itslef a proposition and then define lemmas which prove that some type is a proposition:
+For example, we can prove that {%ard%} isProp {%endard%} is itself a proposition and then define lemmas which prove that some type is a proposition:
 {% arend %}
 \func isProp (A : \Type) => \Pi (a a' : A) -> a = a'
   \where \use \level proof (A : \Type) : isProp (isProp A) => {?} -- the proof is omitted

--- a/src/documentation/language-reference/definitions/records.md
+++ b/src/documentation/language-reference/definitions/records.md
@@ -59,7 +59,7 @@ See [Class extensions](../expressions/class-ext) for more information about new 
 \func r2 => \new R { | p_1 => a_1 ... | p_n => a_n | f_1 => b_1 ... | f_k => b_k }
 \func r3 => \new R a_1 ... a_n b_1 ... b_k
 \func r4 => \new R a_1 ... a_i { | p_{i+1} => a_{i+1} ... | p_n => a_n | f_1 => b_1 ... | f_k => b_k }
-\func r5 => \new R a_1 ... a_n b_1 ... b_i { f_{i+1} => b_{i+1} ... | f_k => b_k }
+\func r5 => \new R a_1 ... a_n b_1 ... b_i { | f_{i+1} => b_{i+1} ... | f_k => b_k }
 {% endarend %}
 
 The same function can also be defined using [copattern matching](functions#copattern-matching):


### PR DESCRIPTION
In particular:
- correction of a record creation syntax, initial `|` was forgotten;
- making one `i` to be emphasized since it's a math symbol;
- seemingly unintentional shadowing in the `\level` example was fixed;
- a typo fix.